### PR TITLE
Set iOS15 as target for objects

### DIFF
--- a/Sources/SnapPix/ImagePicker.swift
+++ b/Sources/SnapPix/ImagePicker.swift
@@ -9,7 +9,7 @@ import SwiftUI
 import UIKit
 
 /// A SwiftUI representation of an image picker.
-@available(iOS 13.0, *)
+@available(iOS 15.0, *)
 struct ImagePicker: UIViewControllerRepresentable {
     /// The source type for the image picker.
     var sourceType: UIImagePickerController.SourceType = .photoLibrary
@@ -39,7 +39,7 @@ struct ImagePicker: UIViewControllerRepresentable {
 }
 
 /// A coordinator to manage the UIImagePickerController.
-@available(iOS 13.0, *)
+@available(iOS 15.0, *)
 class ImagePickerViewCoordinator: NSObject, UINavigationControllerDelegate, UIImagePickerControllerDelegate {
     /// Binding to the selected UIImage.
     @Binding var uiImage: UIImage?
@@ -68,7 +68,7 @@ class ImagePickerViewCoordinator: NSObject, UINavigationControllerDelegate, UIIm
 }
 
 /// A preview for the ImagePicker.
-@available(iOS 13.0, *)
+@available(iOS 15.0, *)
 #Preview {
     ImagePicker(uiImage: .constant(UIImage(named: "Apple")), isPresented: .constant(true))
 }


### PR DESCRIPTION
Not sure about this proposal so correct me if I'm wrong. From what I see in package description, this package target OS version is iOS15. So I assumed it makes sense to reflect it in availability marks as well
<img width="298" alt="image" src="https://github.com/Bereyziat-Development/SnapPix/assets/13601748/32ddca50-d0a9-491d-bfa9-aea046646d2c">
